### PR TITLE
Update version constraint of docile gem

### DIFF
--- a/rggen-core.gemspec
+++ b/rggen-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_runtime_dependency 'docile', '>= 1.1.5'
+  spec.add_runtime_dependency 'docile', '>= 1.1.5', '!= 1.3.3'
   spec.add_runtime_dependency 'erubi', '>= 1.7'
   spec.add_runtime_dependency 'facets', '>= 3.0'
 


### PR DESCRIPTION
Docile 1.3.3 cannot be used due to ms-ati/docile#50.
This PR is to update version constraint of docile gem to avoid this issue.
