### PR TITLE
Add workaround for Docile's issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :rggen do
     instance_eval(File.read(gemfile_path), gemfile_path, 1)
 
   if ENV['USE_FIXED_GEMS'] == 'yes'
-    ['facets'].each do |library|
+    ['docile', 'facets'].each do |library|
       library_path = File.expand_path("../#{library}", __dir__)
       if Dir.exist?(library_path) && !ENV['USE_GITHUB_REPOSITORY']
         gem library, path: library_path

--- a/lib/rggen/core/input_base/input_data.rb
+++ b/lib/rggen/core/input_base/input_data.rb
@@ -79,7 +79,14 @@ module RgGen
 
         def position_from_caller
           locations = caller_locations(3, 2)
-          locations[0].path.include?('docile') ? locations[1] : locations[0]
+          if Docile::VERSION == '1.3.3' && locations[0].path.include?('(eval)')
+            # workaround for ms-ati/docile#50
+            locations[1]
+          elsif locations[0].path.include?('docile')
+            locations[1]
+          else
+            locations[0]
+          end
         end
 
         def create_child_data(layer, &block)


### PR DESCRIPTION
Add workaround for ms-ati/docile#50.
The docile including the above PR will be released:

* remove this workaround
* update version constraint of docile gem to exclude docile 1.3.3
