### PR TITLE
restore FeatureRegistory#enabled_features

### DIFF
--- a/lib/rggen/core/builder/feature_registry.rb
+++ b/lib/rggen/core/builder/feature_registry.rb
@@ -69,6 +69,15 @@ module RgGen
           end
         end
 
+        def enabled_features(list_name = nil)
+          if list_name
+            enabled_list_features(list_name)
+          else
+            @enabled_features.empty? && @feature_entries.keys ||
+              @enabled_features.keys & @feature_entries.keys
+          end
+        end
+
         def build_factories
           target_features =
             (@enabled_features.empty? && @feature_entries || @enabled_features).keys
@@ -87,6 +96,19 @@ module RgGen
           entry = FEATURE_ENTRIES[type].new(self, name)
           entry.setup(@base_feature, @factory, context, &body)
           @feature_entries[name] = entry
+        end
+
+        def enabled_list_features(list_name)
+          return [] unless enabled_list?(list_name)
+          features = @feature_entries[list_name].features
+          (@enabled_features[list_name] || features) & features
+        end
+
+        def enabled_list?(list_name)
+          return false unless list_feature?(list_name)
+          return true if @enabled_features.empty?
+          return true if @enabled_features.key?(list_name)
+          false
         end
 
         def build_factory(entry)

--- a/lib/rggen/core/builder/list_feature_entry.rb
+++ b/lib/rggen/core/builder/list_feature_entry.rb
@@ -77,6 +77,10 @@ module RgGen
           @features.key?(feature)
         end
 
+        def features
+          @features.keys
+        end
+
         private
 
         def attach_shared_context(context)

--- a/spec/rggen/core/builder/feature_registry_spec.rb
+++ b/spec/rggen/core/builder/feature_registry_spec.rb
@@ -284,4 +284,53 @@ RSpec.describe RgGen::Core::Builder::FeatureRegistry do
       expect(registry.feature?(:bar_1, :bar_1_0)).to be false
     end
   end
+
+  describe '#enabled_features' do
+    before do
+      [:foo_0, :foo_1, :foo_2].each do |feature|
+        registry.define_simple_feature(feature) {}
+      end
+      [:bar_0].each do |feature|
+        registry.define_list_feature(feature) {}
+      end
+      [:bar_0_0, :bar_0_1, :bar_0_2].each do |feature|
+        registry.define_list_item_feature(:bar_0, feature) {}
+      end
+      [:bar_1].each do |feature|
+        registry.define_list_feature(feature) {}
+      end
+      [:bar_1_0, :bar_1_1, :bar_1_2].each do |feature|
+        registry.define_list_item_feature(:bar_1, feature) {}
+      end
+    end
+
+    context '無引数の場合' do
+      it '定義済みかつ有効になっているフィーチャーの一覧を返す' do
+        expect(registry.enabled_features).to match([:foo_0, :foo_1, :foo_2, :bar_0, :bar_1])
+
+        registry.enable([:bar_0, :foo_2, :foo_0, :baz_0])
+        expect(registry.enabled_features).to match([:bar_0, :foo_2, :foo_0])
+
+        registry.enable_all
+        registry.enable([:baz_0, :qux_0])
+        expect(registry.enabled_features).to be_empty
+      end
+    end
+
+    context 'リスト名が与えられた場合' do
+      it 'リスト内で定義済みかつ有効になっているフィーチャー名を返す' do
+        expect(registry.enabled_features(:foo_0)).to be_empty
+        expect(registry.enabled_features(:bar_0)).to match([:bar_0_0, :bar_0_1, :bar_0_2])
+        expect(registry.enabled_features(:bar_1)).to match([:bar_1_0, :bar_1_1, :bar_1_2])
+        expect(registry.enabled_features(:baz_0)).to be_empty
+
+        registry.enable(:bar_0)
+        expect(registry.enabled_features(:bar_0)).to match([:bar_0_0, :bar_0_1, :bar_0_2])
+        expect(registry.enabled_features(:bar_1)).to be_empty
+
+        registry.enable(:bar_0, [:bar_0_2, :bar_0_0])
+        expect(registry.enabled_features(:bar_0)).to match([:bar_0_2, :bar_0_0])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Restore `FeatureRegistory#enabled_features` because it's used by `rggen-sv-rtl` plugin.