### PR TITLE
Get position info from input YAML files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,15 @@ inherit_gem:
 inherit_from:
   - .rubocop_todo.yml
 <% end %>
+
+Metrics/ParameterLists:
+  Exclude:
+    - lib/rggen/core/input_base/yaml_loader.rb
+
+Naming/AccessorMethodName:
+  Exclude:
+    - lib/rggen/core/input_base/yaml_loader.rb
+
+Naming/MethodName:
+  Exclude:
+    - lib/rggen/core/core_extensions/kernel.rb

--- a/lib/rggen/core.rb
+++ b/lib/rggen/core.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'delegate'
 require 'docile'
 require 'erubi'
 require 'fileutils'
@@ -14,6 +15,7 @@ require 'yaml'
 require_relative 'core/version'
 
 require_relative 'core/facets'
+require_relative 'core/core_extensions/kernel'
 require_relative 'core/core_extensions/object'
 
 require_relative 'core/utility/attribute_setter'

--- a/lib/rggen/core.rb
+++ b/lib/rggen/core.rb
@@ -26,6 +26,7 @@ require_relative 'core/utility/code_utility/structure_definition'
 require_relative 'core/utility/code_utility'
 require_relative 'core/utility/error_utility'
 require_relative 'core/utility/regexp_patterns'
+require_relative 'core/utility/type_checker'
 
 require_relative 'core/exceptions'
 

--- a/lib/rggen/core/builder/plugin_manager.rb
+++ b/lib/rggen/core/builder/plugin_manager.rb
@@ -88,8 +88,8 @@ module RgGen
         end
 
         def activate_plugins
-          @plugins.each { |plugin| plugin.activate(@builder) }
-          @plugins.each { |plugin| plugin.activate_additionally(@builder) }
+          do_normal_activation
+          do_addtional_activation
         end
 
         def activate_plugin_by_name(plugin_name)
@@ -135,6 +135,14 @@ module RgGen
             &.split(':')
             &.reject(&:blank?)
             &.map { |entry| entry.split(',', 2) }
+        end
+
+        def do_normal_activation
+          @plugins.each { |plugin| plugin.activate(@builder) }
+        end
+
+        def do_addtional_activation
+          @plugins.each { |plugin| plugin.activate_additionally(@builder) }
         end
       end
     end

--- a/lib/rggen/core/builder/plugin_manager.rb
+++ b/lib/rggen/core/builder/plugin_manager.rb
@@ -47,7 +47,7 @@ module RgGen
         def find_gemspec_by_path(path)
           Gem::Specification
             .each.find { |spec| match_gemspec_path?(spec, path) }
-            .yield_self { |spec| spec && [spec.name, spec.version] }
+            .then { |spec| spec && [spec.name, spec.version] }
         end
 
         def match_gemspec_path?(gemspec, path)

--- a/lib/rggen/core/configuration/error.rb
+++ b/lib/rggen/core/configuration/error.rb
@@ -7,7 +7,8 @@ module RgGen
       end
 
       module RaiseError
-        def error(message, position = nil)
+        def error(message, input_value = nil)
+          position = input_value.position if input_value.respond_to?(:position)
           raise ConfigurationError.new(message, position || @position)
         end
       end

--- a/lib/rggen/core/core_extensions/kernel.rb
+++ b/lib/rggen/core/core_extensions/kernel.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Kernel
+  alias_method :__orignal_Integer, :Integer
+
+  def Integer(arg, base = 0, exception: true)
+    arg = arg.__getobj__ if arg.is_a?(::Delegator)
+    __orignal_Integer(arg, base, exception: exception)
+  end
+
+  module_function :__orignal_Integer
+  module_function :Integer
+end

--- a/lib/rggen/core/core_extensions/object.rb
+++ b/lib/rggen/core/core_extensions/object.rb
@@ -4,8 +4,8 @@ class Object
   def export_instance_variable(variable, to)
     instance_variable_defined?(variable) &&
       instance_variable_get(variable)
-        .yield_self { |v| block_given? ? yield(v) : v }
-        .yield_self { |v| to.instance_variable_set(variable, v) }
+        .then { |v| block_given? ? yield(v) : v }
+        .then { |v| to.instance_variable_set(variable, v) }
   end
 
   def singleton_exec(*args, &block)

--- a/lib/rggen/core/input_base/feature.rb
+++ b/lib/rggen/core/input_base/feature.rb
@@ -133,10 +133,9 @@ module RgGen
 
         def do_build(args)
           @position = args.last.position
-          value = args.last.value
-          match_automatically? && match_pattern(value)
+          match_automatically? && match_pattern(args.last)
           Array(self.class.builders)
-            .each { |builder| instance_exec(*args[0..-2], value, &builder) }
+            .each { |builder| instance_exec(*args, &builder) }
         end
 
         attr_reader :position

--- a/lib/rggen/core/input_base/feature.rb
+++ b/lib/rggen/core/input_base/feature.rb
@@ -5,6 +5,7 @@ module RgGen
     module InputBase
       class Feature < Base::Feature
         include Utility::RegexpPatterns
+        include Utility::TypeChecker
 
         class << self
           def property(name, **options, &body)

--- a/lib/rggen/core/input_base/feature_factory.rb
+++ b/lib/rggen/core/input_base/feature_factory.rb
@@ -4,6 +4,8 @@ module RgGen
   module Core
     module InputBase
       class FeatureFactory < Base::FeatureFactory
+        include Utility::TypeChecker
+
         class << self
           def convert_value(&block)
             @value_converter = block

--- a/lib/rggen/core/input_base/input_matcher.rb
+++ b/lib/rggen/core/input_base/input_matcher.rb
@@ -13,8 +13,8 @@ module RgGen
         def match(rhs)
           rhs
             .to_s
-            .yield_self { |s| ignore_blanks? && delete_blanks(s) || s }
-            .yield_self(&method(:match_patterns))
+            .then { |s| ignore_blanks? && delete_blanks(s) || s }
+            .then(&method(:match_patterns))
         end
 
         def match_automatically?

--- a/lib/rggen/core/input_base/input_value.rb
+++ b/lib/rggen/core/input_base/input_value.rb
@@ -3,18 +3,22 @@
 module RgGen
   module Core
     module InputBase
-      class InputValue
+      class InputValue < ::SimpleDelegator
         def initialize(value, position)
-          @value = (value.is_a?(String) && value.strip) || value
+          super((value.is_a?(String) && value.strip) || value)
           @position = position
         end
 
-        attr_accessor :value
+        alias_method :value, :__getobj__
         attr_reader :position
 
+        def match_class?(klass)
+          __getobj__.is_a?(klass)
+        end
+
         def empty_value?
-          return true if @value.nil?
-          return true if @value.respond_to?(:empty?) && @value.empty?
+          return true if value.nil?
+          return true if value.respond_to?(:empty?) && value.empty?
           false
         end
 

--- a/lib/rggen/core/input_base/property.rb
+++ b/lib/rggen/core/input_base/property.rb
@@ -80,8 +80,8 @@ module RgGen
 
         def set_initial_value(feature, varible_name)
           @options[:initial]
-            .yield_self { |v| evaluate_default_initial_value(feature, v) }
-            .yield_self { |v| feature.instance_variable_set(varible_name, v) }
+            .then { |v| evaluate_default_initial_value(feature, v) }
+            .then { |v| feature.instance_variable_set(varible_name, v) }
         end
 
         def evaluate_default_initial_value(feature, value)

--- a/lib/rggen/core/input_base/yaml_loader.rb
+++ b/lib/rggen/core/input_base/yaml_loader.rb
@@ -50,8 +50,8 @@ module RgGen
 
         class Visitor < ::Psych::Visitors::ToRuby
           if ::Psych::VERSION >= '3.2.0'
-            def initialize(ss, class_loader)
-              super(ss, class_loader, symbolize_names: true)
+            def initialize(scalar_scanner, class_loader)
+              super(scalar_scanner, class_loader, symbolize_names: true)
             end
           end
 
@@ -100,7 +100,8 @@ module RgGen
           return result if ::Psych::VERSION >= '3.2.0'
 
           if result.match_class?(Hash)
-            result.keys.each do |key|
+            keys = result.keys
+            keys.each do |key|
               result[key.to_sym] = symbolize_names(result.delete(key))
             end
           elsif result.match_class?(Array)

--- a/lib/rggen/core/input_base/yaml_loader.rb
+++ b/lib/rggen/core/input_base/yaml_loader.rb
@@ -4,15 +4,110 @@ module RgGen
   module Core
     module InputBase
       module YAMLLoader
+        Position = Struct.new(:file, :line, :column) do
+          def to_s
+            "file #{file} line #{line} column #{column}"
+          end
+        end
+
+        module PsychExtension
+          refine ::Psych::Nodes::Node do
+            attr_accessor :filename
+
+            attr_writer :mapping_key
+
+            def mapping_key?
+              @mapping_key || false
+            end
+          end
+        end
+
+        using PsychExtension
+
+        class TreeBuilder < ::Psych::TreeBuilder
+          def initialize(filename)
+            super()
+            @filename = filename
+          end
+
+          def set_start_location(node)
+            super
+            node.filename = @filename
+          end
+
+          def scalar(value, anchor, tag, plain, quated, style)
+            node = super
+            node.mapping_key = mapping_key?
+            node
+          end
+
+          private
+
+          def mapping_key?
+            @last.mapping? && @last.children.size.odd?
+          end
+        end
+
+        class Visitor < ::Psych::Visitors::ToRuby
+          if ::Psych::VERSION >= '3.2.0'
+            def initialize(ss, class_loader)
+              super(ss, class_loader, symbolize_names: true)
+            end
+          end
+
+          def register(node, object)
+            obj =
+              if override_object?(node)
+                file = node.filename
+                line = node.start_line + 1
+                column = node.start_column + 1
+                position = Position.new(file, line, column)
+                InputValue.new(object, position)
+              else
+                object
+              end
+            super(node, obj)
+          end
+
+          private
+
+          def override_object?(node)
+            node.mapping? || node.sequence? || (node.scalar? && !node.mapping_key?)
+          end
+        end
+
         private
 
         def load_yaml(file)
-          yaml = File.binread(file)
-          YAML.safe_load(
-            yaml,
-            permitted_classes: [Symbol], aliases: true,
-            filename: file, symbolize_names: true
-          )
+          parse_yaml(File.binread(file), file)
+            .then { |result| to_ruby(result) }
+            .then { |result| symbolize_names(result) }
+        end
+
+        def parse_yaml(yaml, file)
+          parser = ::Psych::Parser.new(TreeBuilder.new(file))
+          parser.parse(yaml, file)
+          parser.handler.root.children.first
+        end
+
+        def to_ruby(result)
+          cl = ::Psych::ClassLoader::Restricted.new(['Symbol'], [])
+          ss = ::Psych::ScalarScanner.new(cl)
+          Visitor.new(ss, cl).accept(result)
+        end
+
+        def symbolize_names(result)
+          return result if ::Psych::VERSION >= '3.2.0'
+
+          if result.match_class?(Hash)
+            result.keys.each do |key|
+              result[key.to_sym] = symbolize_names(result.delete(key))
+            end
+          elsif result.match_class?(Array)
+            result.map! { |value| symbolize_names(value) }
+          end
+
+          result
         end
       end
     end

--- a/lib/rggen/core/options.rb
+++ b/lib/rggen/core/options.rb
@@ -119,7 +119,7 @@ module RgGen
     Options.add_option(:configuration) do |option|
       option.short_option '-c'
       option.long_option '--configuration FILE'
-      option.default { ENV['RGGEN_DEFAULT_CONFIGURATION_FILE'] }
+      option.default { ENV.fetch('RGGEN_DEFAULT_CONFIGURATION_FILE', nil) }
       option.description 'Specify a configuration file'
     end
 

--- a/lib/rggen/core/register_map/error.rb
+++ b/lib/rggen/core/register_map/error.rb
@@ -7,7 +7,8 @@ module RgGen
       end
 
       module RaiseError
-        def error(message, position = nil)
+        def error(message, input_value = nil)
+          position = input_value.position if input_value.respond_to?(:position)
           raise RegisterMapError.new(message, position || @position)
         end
       end

--- a/lib/rggen/core/register_map/hash_loader.rb
+++ b/lib/rggen/core/register_map/hash_loader.rb
@@ -39,7 +39,7 @@ module RgGen
         end
 
         def format_sub_layer_data(read_data, layer, file)
-          if read_data.is_a?(Array)
+          if array?(read_data)
             format_array_sub_layer_data(read_data, layer, file)
           else
             format_hash_sub_layer_data(read_data, layer, file)
@@ -66,6 +66,11 @@ module RgGen
           else
             sub_layer_data << [key, value]
           end
+        end
+
+        def array?(read_data)
+          return read_data.match_class?(Array) if read_data.respond_to?(:match_class?)
+          read_data.is_a?(Array)
         end
 
         def convert_to_hash(read_data, file)

--- a/lib/rggen/core/register_map/hash_loader.rb
+++ b/lib/rggen/core/register_map/hash_loader.rb
@@ -4,6 +4,8 @@ module RgGen
   module Core
     module RegisterMap
       module HashLoader
+        include Utility::TypeChecker
+
         private
 
         SUB_LAYER_KEYS = {
@@ -21,7 +23,7 @@ module RgGen
         }.freeze
 
         def format_layer_data(read_data, layer, file)
-          if read_data.is_a?(Array)
+          if array?(read_data)
             format_array_layer_data(read_data, layer, file)
           else
             fomrat_hash_layer_data(read_data, layer, file)
@@ -66,11 +68,6 @@ module RgGen
           else
             sub_layer_data << [key, value]
           end
-        end
-
-        def array?(read_data)
-          return read_data.match_class?(Array) if read_data.respond_to?(:match_class?)
-          read_data.is_a?(Array)
         end
 
         def convert_to_hash(read_data, file)

--- a/lib/rggen/core/utility/type_checker.rb
+++ b/lib/rggen/core/utility/type_checker.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RgGen
+  module Core
+    module Utility
+      module TypeChecker
+        [String, Symbol, Integer, Array, Hash].each do |klass|
+          module_eval(<<~DEFINE_METHOD, __FILE__, __LINE__ + 1)
+            # module_function def string?(value)
+            #   return value.match_class?(String) if value.respond_to?(:match_class?)
+            #   value.is_a?(String)
+            # end
+            module_function def #{klass.to_s.downcase}?(value)
+              return value.match_class?(#{klass}) if value.respond_to?(:match_class?)
+              value.is_a?(#{klass})
+            end
+          DEFINE_METHOD
+        end
+      end
+    end
+  end
+end

--- a/spec/rggen/core/configuration/raise_error_spec.rb
+++ b/spec/rggen/core/configuration/raise_error_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe RgGen::Core::Configuration::RaiseError do
       Class.new do
         include RgGen::Core::Configuration::RaiseError
         attr_writer :position
-        def error_test(message, position = nil)
-          if position
-            error message, position
+        def error_test(message, input_value = nil)
+          if input_value
+            error message, input_value
           else
             error message
           end
@@ -25,7 +25,7 @@ RSpec.describe RgGen::Core::Configuration::RaiseError do
     end
 
     context '位置情報がない場合' do
-      it '与えられたメッセージで、ConfigurationError を発生させる' do
+      it '与えられたメッセージでConfigurationErrorを発生させる' do
         expect {
           object.error_test(message)
         }.to raise_rggen_error configuration_error, message
@@ -33,7 +33,7 @@ RSpec.describe RgGen::Core::Configuration::RaiseError do
     end
 
     context 'エラーの発生元が位置情報を持つ場合' do
-      it '位置情報と与えられたメッセージで、ConfigurationError を発生させる' do
+      it '位置情報と与えられたメッセージでConfigurationErrorを発生させる' do
         object.position = positions[0]
         expect {
           object.error_test(message)
@@ -41,16 +41,37 @@ RSpec.describe RgGen::Core::Configuration::RaiseError do
       end
     end
 
-    context '位置情報が与えられた場合' do
-      it '与えられた位置情報とメッセージで、ConfigurationError を発生させる' do
+    context '与えられた入力値が位置情報を持つ場合' do
+      let(:input_value) do
+        RgGen::Core::InputBase::InputValue.new(0, positions[1])
+      end
+
+      it '入力値が持つ位置情報と与えられたメッセージでConfigurationErrorを発生させる' do
         expect {
-          object.error_test(message, positions[1])
+          object.error_test(message, input_value)
         }.to raise_rggen_error configuration_error, message, positions[1]
 
         object.position = positions[0]
         expect {
-          object.error_test(message, positions[1])
+          object.error_test(message, input_value)
         }.to raise_rggen_error configuration_error, message, positions[1]
+      end
+    end
+
+    context '与えられた入力値が位置情報を持たない場合' do
+      let(:input_value) do
+        0
+      end
+
+      it '与えられたメッセージでConfigurationErrorを発生させる' do
+        expect {
+          object.error_test(message, input_value)
+        }.to raise_rggen_error configuration_error, message
+
+        object.position = positions[0]
+        expect {
+          object.error_test(message, input_value)
+        }.to raise_rggen_error configuration_error, message, positions[0]
       end
     end
   end

--- a/spec/rggen/core/configuration/yaml_loader_spec.rb
+++ b/spec/rggen/core/configuration/yaml_loader_spec.rb
@@ -48,11 +48,18 @@ RSpec.describe RgGen::Core::Configuration::YAMLLoader do
       allow(File).to receive(:binread).and_return(file_content)
     end
 
+    def position(line, column)
+      RgGen::Core::InputBase::YAMLLoader::Position.new(file, line, column)
+    end
+
     it '入力ファイルを元に、入力データを組み立てる' do
       loader.load_file(file, input_data, valid_value_lists)
       expect(input_data).to have_values(
-        [:foo, 0, file], [:bar, 1, file], [:baz, 2, file],
-        [:fizz, 'fizz', file], [:buzz, :buzz, file]
+        [:foo, 0, position(1, 6)],
+        [:bar, 1, position(2, 6)],
+        [:baz, 2, position(3, 6)],
+        [:fizz, 'fizz', position(4, 7)],
+        [:buzz, :buzz, position(5, 7)]
       )
     end
   end

--- a/spec/rggen/core/input_base/feature_spec.rb
+++ b/spec/rggen/core/input_base/feature_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe RgGen::Core::InputBase::Feature do
   describe '#build' do
     let(:feature) do
       create_feature do
-        build { |*args| foo(*args) }
+        build { |*args| foo(*args.map(&:value)) }
       end
     end
 
     let(:child_feature) do
       create_feature(feature.class) do
-        build { |*args| bar(*args) }
+        build { |*args| bar(*args.map(&:value)) }
       end
     end
 
@@ -116,9 +116,12 @@ RSpec.describe RgGen::Core::InputBase::Feature do
       feature.build(input_value)
     end
 
-    specify '入力データの#valueが組み立てブロックに渡される' do
+    specify '入力データが組み立てブロックに渡される' do
       expect(feature).to receive(:foo).with(equal(value))
       feature.build(input_value)
+
+      expect(feature).to receive(:foo).with(equal(other_value), equal(value))
+      feature.build(other_input_value, input_value)
     end
 
     specify '入力データの#positionは、フィーチャー内に#positionとして保持される' do
@@ -127,8 +130,8 @@ RSpec.describe RgGen::Core::InputBase::Feature do
       expect(feature.send(:position)).to eq position
     end
 
-    specify '#value/#positionの取り出しは、末尾の入力値に対して行われる' do
-      expect(feature).to receive(:foo).with(equal(other_input_value), equal(value))
+    specify '#positionの取り出しは、末尾の入力値に対して行われる' do
+      allow(feature).to receive(:foo)
       feature.build(other_input_value, input_value)
       expect(feature.send(:position)).to eq position
     end
@@ -272,7 +275,7 @@ RSpec.describe RgGen::Core::InputBase::Feature do
         end
 
         it '#build実行時に、自動で末尾の引数に対して一致比較を行う' do
-          expect(feature).to receive(:match_pattern).with(:bar)
+          expect(feature).to receive(:match_pattern).with(eq(:bar))
           feature.build(*input_values)
         end
       end

--- a/spec/rggen/core/input_base/yaml_loader_spec.rb
+++ b/spec/rggen/core/input_base/yaml_loader_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe RgGen::Core::InputBase::YAMLLoader do
+  describe '#load_yaml' do
+    let(:loader) do
+      klass = Class.new(RgGen::Core::InputBase::Loader) do
+        include RgGen::Core::InputBase::YAMLLoader
+        support_types [:yaml]
+
+        def read_file(file)
+          load_yaml(file)
+        end
+
+        def format_layer_data(read_data, _layer, _file)
+          Hash(read_data)
+        end
+      end
+      klass.new([], {})
+    end
+
+    let(:valid_value_lists) do
+      { nil => [:foo, :bar, :baz, :fizz, :buzz] }
+    end
+
+    let(:file) do
+      'test.yaml'
+    end
+
+    let(:input_data) do
+      RgGen::Core::Configuration::InputData.new(valid_value_lists)
+    end
+
+    let(:file_content) do
+      <<~'YAML'
+        foo: 0
+        bar: [1, 2]
+        baz: {baz_3: 3, baz_4: 4}
+        fizz:
+          <<: &fizz_buzz
+            fizz_buzz: [5, 6]
+        buzz:
+          <<: *fizz_buzz
+      YAML
+    end
+
+    before do
+      allow(File).to receive(:readable?).and_return(true)
+      allow(File).to receive(:binread).and_return(file_content)
+    end
+
+    def position(line, column)
+      RgGen::Core::InputBase::YAMLLoader::Position.new(file, line, column)
+    end
+
+    specify '読みだした値は位置情報を持つ' do
+      loader.load_file(file, input_data, valid_value_lists)
+      expect(input_data[:foo]).to match_value(0, position(1, 6))
+      expect(input_data[:bar].value[0]).to match_value(1, position(2, 7))
+      expect(input_data[:bar].value[1]).to match_value(2, position(2, 10))
+      expect(input_data[:baz].value[:baz_3]).to match_value(3, position(3, 14))
+      expect(input_data[:baz].value[:baz_4]).to match_value(4, position(3, 24))
+      expect(input_data[:fizz].value[:fizz_buzz][0]).to match_value(5, position(6, 17))
+      expect(input_data[:fizz].value[:fizz_buzz][1]).to match_value(6, position(6, 20))
+      expect(input_data[:buzz].value[:fizz_buzz][0]).to match_value(5, position(6, 17))
+      expect(input_data[:buzz].value[:fizz_buzz][1]).to match_value(6, position(6, 20))
+    end
+  end
+end

--- a/spec/rggen/core/options_spec.rb
+++ b/spec/rggen/core/options_spec.rb
@@ -87,7 +87,7 @@ module RgGen::Core
           let(:configuration_file) { configuration_files.sample }
 
           before do
-            allow(ENV).to receive(:[]).with('RGGEN_DEFAULT_CONFIGURATION_FILE').and_return(configuration_file)
+            allow(ENV).to receive(:fetch).with('RGGEN_DEFAULT_CONFIGURATION_FILE', nil).and_return(configuration_file)
           end
 
           it '当該環境変数で指定されたファイルのパスを返す' do

--- a/spec/rggen/core/register_map/raise_error_spec.rb
+++ b/spec/rggen/core/register_map/raise_error_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe RgGen::Core::RegisterMap::RaiseError do
       Class.new do
         include RgGen::Core::RegisterMap::RaiseError
         attr_writer :position
-        def error_test(message, position = nil)
-          if position
-            error message, position
+        def error_test(message, input_value = nil)
+          if input_value
+            error message, input_value
           else
             error message
           end
@@ -25,7 +25,7 @@ RSpec.describe RgGen::Core::RegisterMap::RaiseError do
     end
 
     context '位置情報がない場合' do
-      it '与えられたメッセージで、RegisterMapError を発生させる' do
+      it '与えられたメッセージでRegisterMapErrorを発生させる' do
         expect {
           object.error_test(message)
         }.to raise_rggen_error register_map_error, message
@@ -33,7 +33,7 @@ RSpec.describe RgGen::Core::RegisterMap::RaiseError do
     end
 
     context 'エラーの発生元が位置情報を持つ場合' do
-      it '位置情報と与えられたメッセージで、RegisterMapError を発生させる' do
+      it '位置情報と与えられたメッセージでRegisterMapErrorを発生させる' do
         object.position = positions[0]
         expect {
           object.error_test(message)
@@ -41,16 +41,37 @@ RSpec.describe RgGen::Core::RegisterMap::RaiseError do
       end
     end
 
-    context '位置情報が与えられた場合' do
-      it '与えられた位置情報とメッセージで、RegisterMapError を発生させる' do
+    context '与えられた入力値が位置情報を持つ場合' do
+      let(:input_value) do
+        RgGen::Core::InputBase::InputValue.new(0, positions[1])
+      end
+
+      it '入力値が持つ位置情報と与えられたメッセージでRegisterMapErrorを発生させる' do
         expect {
-          object.error_test(message, positions[1])
+          object.error_test(message, input_value)
         }.to raise_rggen_error register_map_error, message, positions[1]
 
         object.position = positions[0]
         expect {
-          object.error_test(message, positions[1])
+          object.error_test(message, input_value)
         }.to raise_rggen_error register_map_error, message, positions[1]
+      end
+    end
+
+    context '与えられた入力値が位置情報を持たない場合' do
+      let(:input_value) do
+        0
+      end
+
+      it '与えられたメッセージでRegisterMapErrorを発生させる' do
+        expect {
+          object.error_test(message, input_value)
+        }.to raise_rggen_error register_map_error, message
+
+        object.position = positions[0]
+        expect {
+          object.error_test(message, input_value)
+        }.to raise_rggen_error register_map_error, message, positions[0]
       end
     end
   end

--- a/spec/rggen/core/utility/type_checker_spec.rb
+++ b/spec/rggen/core/utility/type_checker_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe RgGen::Core::Utility::TypeChecker do
+  def input_value(value)
+    RgGen::Core::InputBase::InputValue.new(value, nil)
+  end
+
+  let(:checker) do
+    described_class
+  end
+
+  let(:string_value) do
+    'foo'
+  end
+
+  let(:symbol_value) do
+    :foo
+  end
+
+  let(:integer_value) do
+    1
+  end
+
+  let(:array_value) do
+    []
+  end
+
+  let(:hash_value) do
+    {}
+  end
+
+  let(:object_value) do
+    Object.new
+  end
+
+  describe '#string?' do
+    it '与えられた引数が文字列かどうかを返す' do
+      expect(checker.string?(string_value)).to be true
+      expect(checker.string?(input_value(string_value))).to be true
+
+      expect(checker.string?(symbol_value)).to be false
+      expect(checker.string?(input_value(symbol_value))).to be false
+
+      expect(checker.string?(integer_value)).to be false
+      expect(checker.string?(input_value(integer_value))).to be false
+
+      expect(checker.string?(array_value)).to be false
+      expect(checker.string?(input_value(array_value))).to be false
+
+      expect(checker.string?(hash_value)).to be false
+      expect(checker.string?(input_value(hash_value))).to be false
+
+      expect(checker.string?(object_value)).to be false
+      expect(checker.string?(input_value(object_value))).to be false
+    end
+  end
+
+  describe '#symbol?' do
+    it '与えられた引数がシンボルかどうかを返す' do
+      expect(checker.symbol?(string_value)).to be false
+      expect(checker.symbol?(input_value(string_value))).to be false
+
+      expect(checker.symbol?(symbol_value)).to be true
+      expect(checker.symbol?(input_value(symbol_value))).to be true
+
+      expect(checker.symbol?(integer_value)).to be false
+      expect(checker.symbol?(input_value(integer_value))).to be false
+
+      expect(checker.symbol?(array_value)).to be false
+      expect(checker.symbol?(input_value(array_value))).to be false
+
+      expect(checker.symbol?(hash_value)).to be false
+      expect(checker.symbol?(input_value(hash_value))).to be false
+
+      expect(checker.symbol?(object_value)).to be false
+      expect(checker.symbol?(input_value(object_value))).to be false
+    end
+  end
+
+  describe '#integer?' do
+    it '与えられた引数が整数かどうかを返す' do
+      expect(checker.integer?(string_value)).to be false
+      expect(checker.integer?(input_value(string_value))).to be false
+
+      expect(checker.integer?(symbol_value)).to be false
+      expect(checker.integer?(input_value(symbol_value))).to be false
+
+      expect(checker.integer?(integer_value)).to be true
+      expect(checker.integer?(input_value(integer_value))).to be true
+
+      expect(checker.integer?(array_value)).to be false
+      expect(checker.integer?(input_value(array_value))).to be false
+
+      expect(checker.integer?(hash_value)).to be false
+      expect(checker.integer?(input_value(hash_value))).to be false
+
+      expect(checker.integer?(object_value)).to be false
+      expect(checker.integer?(input_value(object_value))).to be false
+    end
+  end
+
+  describe '#array?' do
+    it '与えられた引数が配列かどうかを返す' do
+      expect(checker.array?(string_value)).to be false
+      expect(checker.array?(input_value(string_value))).to be false
+
+      expect(checker.array?(symbol_value)).to be false
+      expect(checker.array?(input_value(symbol_value))).to be false
+
+      expect(checker.array?(integer_value)).to be false
+      expect(checker.array?(input_value(integer_value))).to be false
+
+      expect(checker.array?(array_value)).to be true
+      expect(checker.array?(input_value(array_value))).to be true
+
+      expect(checker.array?(hash_value)).to be false
+      expect(checker.array?(input_value(hash_value))).to be false
+
+      expect(checker.array?(object_value)).to be false
+      expect(checker.array?(input_value(object_value))).to be false
+    end
+  end
+
+  describe '#hash?' do
+    it '与えられた引数が連想配列かどうかを返す' do
+      expect(checker.hash?(string_value)).to be false
+      expect(checker.hash?(input_value(string_value))).to be false
+
+      expect(checker.hash?(symbol_value)).to be false
+      expect(checker.hash?(input_value(symbol_value))).to be false
+
+      expect(checker.hash?(integer_value)).to be false
+      expect(checker.hash?(input_value(integer_value))).to be false
+
+      expect(checker.hash?(array_value)).to be false
+      expect(checker.hash?(input_value(array_value))).to be false
+
+      expect(checker.hash?(hash_value)).to be true
+      expect(checker.hash?(input_value(hash_value))).to be true
+
+      expect(checker.hash?(object_value)).to be false
+      expect(checker.hash?(input_value(object_value))).to be false
+    end
+  end
+end


### PR DESCRIPTION
For rggen/rggen#100

* Change base class of `InputBase::InputValue` to add delegate functionality and `position` attribute
* Extend YAML loader to get position info from YAML files which are being parsed
