### PR TITLE
add truthy/falsey regexp patterns

### DIFF
--- a/lib/rggen/core/utility/regexp_patterns.rb
+++ b/lib/rggen/core/utility/regexp_patterns.rb
@@ -32,6 +32,18 @@ module RgGen
         def integer
           INTEGER_PATTERN
         end
+
+        TRUTHY_PATTERN = /true|on|yes/i.freeze
+
+        def truthy_pattern
+          TRUTHY_PATTERN
+        end
+
+        FALSEY_PATTERN = /false|off|no/i.freeze
+
+        def falsey_pattern
+          FALSEY_PATTERN
+        end
       end
     end
   end

--- a/spec/rggen/core/utility/regexp_patterns_spec.rb
+++ b/spec/rggen/core/utility/regexp_patterns_spec.rb
@@ -131,5 +131,41 @@ module RgGen::Core::Utility
         end
       end
     end
+
+    describe '#truthy_pattern' do
+      it 'true/on/yesにマッチする' do
+        [
+          /true/i, /on/i, /yes/i
+        ].each do |pattern|
+          string = random_string(pattern)
+          expect(string).to match(regexp_pattern(:truthy_pattern))
+        end
+
+        [
+          /false/i, /off/i, /no/i, /foo/i, /\s*/i
+        ].each do |pattern|
+          string  = random_string(pattern)
+          expect(string).not_to match(regexp_pattern(:truthy_pattern))
+        end
+      end
+    end
+
+    describe '#falsey_pattern' do
+      it 'false/off/noにマッチする' do
+        [
+          /false/i, /off/i, /no/i
+        ].each do |pattern|
+          string = random_string(pattern)
+          expect(string).to match(regexp_pattern(:falsey_pattern))
+        end
+
+        [
+          /true/i, /on/i, /yes/i, /foo/i, /\s*/i
+        ].each do |pattern|
+          string  = random_string(pattern)
+          expect(string).not_to match(regexp_pattern(:falsey_pattern))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is to add regexp patterns showing truthy value and falsey value.
These patterns matche:

* truthy pattern: true/on/yes
* falsey pattern: false/off/no

This is a preparation for rggen/rggen#119.
