### PR TITLE
allow property methods to accept kewword arguments

### DIFF
--- a/lib/rggen/core/base/component.rb
+++ b/lib/rggen/core/base/component.rb
@@ -75,9 +75,13 @@ module RgGen
 
         def define_proxy_call(receiver, method_name)
           (@proxy_receivers ||= {})[method_name.to_sym] = receiver
-          define_singleton_method(method_name) do |*args, &block|
+          define_singleton_method(method_name) do |*args, **keywords, &block|
             name = __method__
-            @proxy_receivers[name].__send__(name, *args, &block)
+            if RUBY_VERSION < '2.7.0' && keywords.empty?
+              @proxy_receivers[name].__send__(name, *args, &block)
+            else
+              @proxy_receivers[name].__send__(name, *args, **keywords, &block)
+            end
           end
         end
       end

--- a/spec/rggen/core/input_base/component_spec.rb
+++ b/spec/rggen/core/input_base/component_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe RgGen::Core::InputBase::Component do
         Class.new(RgGen::Core::InputBase::Feature) { property :foo, default: :foo; property :bar, default: :bar; }
           .new(:feature_0, nil, component),
         Class.new(RgGen::Core::InputBase::Feature) { property :baz, default: :baz }
-          .new(:feature_1, nil, component)
+          .new(:feature_1, nil, component),
+        Class.new(RgGen::Core::InputBase::Feature) { property :qux, body: ->(v, vv:, &b) { v + vv + b.call } }
+          .new(:feature_2, nil, component)
       ]
     end
 
@@ -21,10 +23,12 @@ RSpec.describe RgGen::Core::InputBase::Component do
       expect(features[0]).to receive(:foo).and_call_original
       expect(features[0]).to receive(:bar).and_call_original
       expect(features[1]).to receive(:baz).and_call_original
+      expect(features[2]).to receive(:qux).and_call_original
 
       expect(component.foo).to eq :foo
       expect(component.bar).to eq :bar
       expect(component.baz).to eq :baz
+      expect(component.qux(1, vv: 2) { 3 } ).to eq 6
     end
   end
 

--- a/spec/rggen/core/input_base/property_spec.rb
+++ b/spec/rggen/core/input_base/property_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe RgGen::Core::InputBase::Property do
       end
 
       specify '定義されたプロパティは引数、ブロックを取れる' do
-        define_property(feature, :foo) { |v, &b| v + b.call }
-        expect(feature.foo(2) { 3 }).to eq 5
+        define_property(feature, :foo) { |v, vv:, &b| v + vv + b.call }
+        expect(feature.foo(2, vv: 3) { 4 }).to eq 9
       end
     end
 
@@ -75,8 +75,8 @@ RSpec.describe RgGen::Core::InputBase::Property do
       end
 
       specify '定義されたプロパティは引数、ブロックを取れる' do
-        define_property(feature, :foo, body: ->(v, &b) { v + b.call })
-        expect(feature.foo(2) { 3 }).to eq 5
+        define_property(feature, :foo, body: ->(v, vv:, &b) { v + vv + b.call })
+        expect(feature.foo(2, vv: 3) { 4 }).to eq 9
       end
     end
 
@@ -175,7 +175,7 @@ RSpec.describe RgGen::Core::InputBase::Property do
         create_feature do
           class << self
             def foo; 2; end
-            def bar(v, &b); v + b.call; end
+            def bar(v, vv:, &b); v + vv + b.call; end
           end
 
           def initialize; @foo = 1; end
@@ -190,7 +190,7 @@ RSpec.describe RgGen::Core::InputBase::Property do
 
         specify '定義されるプロパティは引数とブロックを取ることができる' do
           define_property(feature, :bar, forward_to_helper: true)
-          expect(feature.bar(2) { 3 }).to eq 5
+          expect(feature.bar(2, vv: 3) { 4 }).to eq 9
         end
       end
 
@@ -207,7 +207,7 @@ RSpec.describe RgGen::Core::InputBase::Property do
       let(:feature) do
         create_feature do
           def foo; 1; end
-          def bar(v, &b); v + b.call; end
+          def bar(v, vv:, &b); v + vv + b.call; end
         end
       end
 
@@ -219,7 +219,7 @@ RSpec.describe RgGen::Core::InputBase::Property do
 
       specify '定義されるプロパティは引数とブロックを取ることができる' do
         define_property(feature, :barbar, forward_to: :bar)
-        expect(feature.barbar(2) { 3 }).to eq 5
+        expect(feature.barbar(2, vv: 3) { 4 }).to eq 9
       end
     end
 


### PR DESCRIPTION
This PR is preparation for rggen/rggen#127.

Currently, property methods cannot accept keyword arguments.
THis PR is to add such feature to property methods.
